### PR TITLE
fix two warnings caused by a possibly uninitialized variable and a si…

### DIFF
--- a/c_src/dpiStmt_nif.c
+++ b/c_src/dpiStmt_nif.c
@@ -122,7 +122,7 @@ DPI_NIF_FUN(stmt_fetchRows)
     CHECK_ARGCOUNT(2);
 
     dpiStmt_res *stmtRes;
-    uint32_t moreRows;
+    int moreRows;
     uint32_t maxRows;
     uint32_t bufferRowIndex;
     uint32_t numRowsFetched;
@@ -461,7 +461,7 @@ DPI_NIF_FUN(stmt_getInfo)
         info.isReturning ? ATOM_TRUE : ATOM_FALSE,
         &map);
 
-    ERL_NIF_TERM type;
+    ERL_NIF_TERM type = ATOM_ERROR;
 
     switch (info.statementType)
     {


### PR DESCRIPTION
…gnedness mismatch in a pointer variable

Those were the only warnings in oranif with `-Wall` on Ubuntu. There are a bunch of warnings coming from [odpi](https://github.com/oracle/odpi), however:

```gdb
In file included from c_src/odpi/embed/dpi.c:23,
                 from c_src/dpi_nif.c:2:
c_src/odpi/embed/../src/dpiDebug.c: In function â:
c_src/odpi/embed/../src/dpiDebug.c:73:39: warning: implicit declaration of function â [-Wimplicit-function-declaration]
   73 |                 threadId = (uint64_t) syscall(SYS_gettid);
      |                                       ^~~~~~~
c_src/odpi/embed/../src/dpiDebug.c:93:21: warning: implicit declaration of function â; did you mean â? [-Wimplicit-function-declaration]
   93 |                     localtime_r(&timeOfDay.tv_sec, &time);
      |                     ^~~~~~~~~~~
      |                     localtime
```