### PR TITLE
fixes odpi-c compile warning: implicit declaration of function

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -9,7 +9,7 @@ ODPI_LIB_DIR = $(S)/odpi/lib
 TARGET = $(O)/dpi_nif.so
 
 INCLUDEDIRS = -I$(S) -I"$(ERTS_INCLUDE)" -I"$(S)/odpi/include"
-CFLAGS = $(INCLUDEDIRS) -O2 -ggdb -Wall -fPIC -std=c11
+CFLAGS = $(INCLUDEDIRS) -O2 -ggdb -Wall -fPIC -std=c11 -D _GNU_SOURCE
 LDFLAGS = -shared
 
 ifdef LINKODPI


### PR DESCRIPTION
Ref: https://github.com/KonnexionsGmbH/oranif/pull/9 (remaining warnings)
```sh
In file included from c_src/odpi/embed/dpi.c:23,
                 from c_src/dpi_nif.c:2:
c_src/odpi/embed/../src/dpiDebug.c: In function â:
c_src/odpi/embed/../src/dpiDebug.c:73:39: warning: implicit declaration of function â [-Wimplicit-function-declaration]
   73 |                 threadId = (uint64_t) syscall(SYS_gettid);
      |                                       ^~~~~~~
c_src/odpi/embed/../src/dpiDebug.c:93:21: warning: implicit declaration of function â; did you mean â? [-Wimplicit-function-declaration]
   93 |                     localtime_r(&timeOfDay.tv_sec, &time);
      |                     ^~~~~~~~~~~
      |                     localtime
```
Ref: https://stackoverflow.com/questions/42469583/problems-calling-syscall-function-in-c