### PR TITLE
removes github advice while cloning odpi

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -33,7 +33,7 @@ priv:
 
 odpi:
 	@if [ ! -d "$(ODPIROOT)" ]; then \
-		cd $(S) && (git clone -b v3.0.0 --single-branch $(ODPI_REPO)) \
+		cd $(S) && (git clone -b v3.0.0 --single-branch -c advice.detachedHead=false $(ODPI_REPO)) \
 	fi
 	@if [ ! -z "${LINKODPI}" -a ! -d "$(ODPI_LIB_DIR)" ]; then \
 		cd $(ODPIROOT) && (make) \


### PR DESCRIPTION
Following advice will be removed with this PR

```
You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>
```